### PR TITLE
Acquisition updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,21 @@
 Changelog for Nautilus
 ======================
+0.1.13 (2023-03-10)
+-------------------
+
+Fixed:
+^^^^^^
+- Moved output directory check from frame acquistion thread to updateExp method so it's not checking the output directory on every frame callback
+- Change available_space_in_default_drive method so it is defined for non-win32 systems
+- Fix settings output, switch to toml output
+
+Added:
+^^^^^^
+- Check led intensity is > 0.0 before turning on led
+- Switch default output to TiffStack + BigTiff
+- Add horizontal/vertical live view image flipping to config
+- Increase default binning factor
+
 
 0.1.12 (2023-02-27)
 -------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-set(NAUTILUS_VERSION 0.1.12)
+set(NAUTILUS_VERSION 0.1.13)
 
 project(nautilus LANGUAGES CXX C VERSION ${NAUTILUS_VERSION})
 set(PROJECT_BRIEF "Nautilus Acquisition")

--- a/resources/nautilus.toml
+++ b/resources/nautilus.toml
@@ -16,14 +16,19 @@ speed_table_index = 0
 fps = 10.0
 duration = 1.0
 led_intensity = 50.0
+storage_type = 1
 
 [acquisition.region]
 s1 = 800
 p1 = 1000
 s2 = 2399
 p2 = 2199
-sbin = 1
-pbin = 1
+sbin = 2
+pbin = 2
+
+[acquisition.live_view]
+vflip = false
+hflip = true
 
 [device.tango]
 com = "COM3"

--- a/src/app/src/banner.h.in
+++ b/src/app/src/banner.h.in
@@ -27,6 +27,8 @@
  *
  * @brief Software version and application banner strings.
  *********************************************************************/
+#ifndef __BANNER_H__
+#define __BANNER_H__
 #include <string>
 
 std::string version = "@NAUTILUS_VERSION@";
@@ -39,4 +41,5 @@ std::string banner = R"(
 ██║ ╚████║██║  ██║╚██████╔╝   ██║   ██║███████╗╚██████╔╝███████║
 ╚═╝  ╚═══╝╚═╝  ╚═╝ ╚═════╝    ╚═╝   ╚═╝╚══════╝ ╚═════╝ ╚══════╝
 )";
+#endif //__BANNER_H__
 

--- a/src/app/src/liveview.cpp
+++ b/src/app/src/liveview.cpp
@@ -58,10 +58,12 @@ LiveView::~LiveView() {
  * @param height Height of the image.
  * @param fmt ImageFormat type.
  */
-void LiveView::Init(uint32_t width, uint32_t height, ImageFormat fmt) {
+void LiveView::Init(uint32_t width, uint32_t height, bool vflip, bool hflip, ImageFormat fmt) {
     m_width = width;
     m_height = height;
     m_imageInFmt = fmt;
+    m_vflip = vflip;
+    m_hflip = hflip;
 
     SetImageFormat(m_imageInFmt);
 
@@ -127,6 +129,7 @@ void LiveView::UpdateImage(uint8_t* data) {
 
         m_imageData = data;
         m_image = QImage((uchar*)m_imageData,m_width,m_height, m_imageOutFmt).scaled(s, s, Qt::KeepAspectRatio);
+        m_image.mirror(m_hflip, m_vflip);
         this->update();
     }
 }

--- a/src/app/src/liveview.h
+++ b/src/app/src/liveview.h
@@ -51,7 +51,7 @@ class LiveView : public QOpenGLWidget {
         LiveView(QWidget* parent = nullptr);
         virtual ~LiveView();
 
-        void Init(uint32_t width, uint32_t height, ImageFormat fmt);
+        void Init(uint32_t width, uint32_t height, bool vflip, bool hflip, ImageFormat fmt);
         void Clear();
         void UpdateImage(uint8_t* data);
         void SetImageFormat(ImageFormat fmt);
@@ -68,9 +68,11 @@ class LiveView : public QOpenGLWidget {
         uint32_t m_height{0};
         uint32_t m_totalPx{0};
 
+        bool m_vflip{false};
+        bool m_hflip{false};
+
         ImageFormat m_imageInFmt;
         QImage m_image;
-        //QPixmap m_pixmap;
         QRectF m_target;
         QImage::Format m_imageOutFmt;
 };

--- a/src/app/src/mainwindow.h
+++ b/src/app/src/mainwindow.h
@@ -71,6 +71,7 @@ class MainWindow : public QMainWindow {
 
     public:
         explicit MainWindow(
+            std::string version,
             std::string path,
             std::string prefix,
             std::string niDev,
@@ -87,6 +88,8 @@ class MainWindow : public QMainWindow {
             uint16_t exposureMode,
             double maxVoltage,
             bool noAutoConBright,
+            bool vflip, bool hflip,
+            Region& rgn,
             std::string stageComPort,
             std::string configFile,
             toml::value& config,
@@ -137,6 +140,7 @@ class MainWindow : public QMainWindow {
         AdvancedSetupDialog * m_advancedSettingsDialog{nullptr};
         std::string m_stageComPort{};
 
+        std::string m_version;
         Settings* m_settings {nullptr};
         std::mutex m_lock;
 
@@ -169,6 +173,8 @@ class MainWindow : public QMainWindow {
         bool m_acquisitionRunning {false};
         bool m_liveScanRunning {false};
         bool m_autoConBright{true};
+        bool m_vflip{false};
+        bool m_hflip{false};
 
         uint8_t* m_img8;
 
@@ -208,8 +214,7 @@ class MainWindow : public QMainWindow {
         bool ledOFF();
         bool ledSetVoltage(double voltage);
         bool available_space_in_default_drive( double fps,double duration);
-        //acquire helper function
-        void acquire(bool saveToDisk, std::string prefix);
+        void acquire(bool saveToDisk);
 
         static void acquisitionThread(MainWindow* cls);
 };

--- a/src/cameras/src/pm/Acquisition.cpp
+++ b/src/cameras/src/pm/Acquisition.cpp
@@ -141,7 +141,7 @@ void pm::Acquisition<F, C>::frameWriterThread() {
     F* frame{nullptr};
 
     std::string fileName = m_camera->ctx->curExp->filePrefix;
-    std::filesystem::path filePath = m_camera->ctx->curExp->filePath;
+    std::filesystem::path filePath = m_camera->ctx->curExp->acquisitionDir;
 
     TiffFile<F>* file = new TiffFile<F>(
         m_camera->ctx->curExp->region,
@@ -214,12 +214,6 @@ void pm::Acquisition<F, C>::frameWriterThread() {
                         m_latestFrame = frame;
                     }
 
-                    // make subdirectory to write to
-                    if (!std::filesystem::exists(filePath)) {
-                        std::filesystem::create_directories(filePath);
-                        spdlog::info("Acquisition being written under directory: {}", filePath.string());
-                    }
-
                     //TODO support different storage types
                     switch (m_camera->ctx->curExp->storageType) {
                         case StorageType::Tiff:
@@ -233,9 +227,11 @@ void pm::Acquisition<F, C>::frameWriterThread() {
                             file->Open((filePath / (fileName + ss.str() + ".tiff")).string());
                         }
                             break;
-                        case StorageType::TiffStack:
+                        case StorageType::TiffStack: //Defaults to using BigTiff
                             if (frameIndex == 0) {
-                                file->Open((filePath / (fileName + ".tiff")).string());
+                                std::stringstream ss;
+                                ss << std::setfill('0') << std::setw(3) << frameIndex;
+                                file->Open((filePath / (fileName + ss.str() + ".tiff")).string());
                             }
                             break;
                     }

--- a/src/cameras/src/pm/Camera.cpp
+++ b/src/cameras/src/pm/Camera.cpp
@@ -772,12 +772,15 @@ bool pm::Camera<F>::updateExp(const ExpSettings& settings) {
         return false;
     }
 
+
     //copy capture settings
     ctx->curExp.reset(new ExpSettings{
             .acqMode = settings.acqMode,
-            .filePath = settings.filePath,
+            .workingDir = settings.workingDir,
+            .acquisitionDir = settings.acquisitionDir,
             .filePrefix = settings.filePrefix,
             .region = settings.region,
+            .storageType = settings.storageType,
             .spdTableIdx = settings.spdTableIdx,
             .expTimeMS = settings.expTimeMS,
             .trigMode = settings.trigMode,

--- a/src/common/include/TiffFile.h
+++ b/src/common/include/TiffFile.h
@@ -178,7 +178,7 @@ TiffFile<F>::TiffFile(const Region& rgn, const ImageFormat format, uint16_t bitD
     m_frameCount(frameCount),
     m_format(format),
     m_bitDepth(bitDepth),
-    m_useBigTiff(false),
+    m_useBigTiff((frameCount > 1) ? true : false), //Use BigTiff when storage type is TiffStack
     m_bmpFormat(BitmapFormat(format, bitDepth)) {
 }
 

--- a/src/common/include/interfaces/CameraInterface.h
+++ b/src/common/include/interfaces/CameraInterface.h
@@ -111,11 +111,12 @@ struct CameraInfo {
 */
 struct ExpSettings {
     AcqMode acqMode;
-    std::filesystem::path filePath;
+    std::filesystem::path workingDir;
+    std::filesystem::path acquisitionDir;
     std::string filePrefix;
 
     Region region {0};
-    StorageType storageType {StorageType::Tiff};
+    StorageType storageType {StorageType::TiffStack};
     uint16_t spdTableIdx{0};
 
     uint32_t expTimeMS{0};


### PR DESCRIPTION
* Add horizontal/vertical live view image flipping to config
* Switch default output to TiffStack + BigTiff
* Check led intensity is > 0.0 before turning on led
* Move output directory check from frame acquistion thread to `updateExp` method so it's not checking the output directory on every frame callback
* Change `available_space_in_default_drive` method so it is defined for non-win32 systems
* Fix settings output, switch to toml file
* Increase default binning factor
* Bump version