### PR TITLE
parallel write files, use 90% memory for framesMax

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Added:
 ^^^^^^
 - Delete files when autotiling
 - Update plate format files
+- Use thread pool for writing files in parallel
+- Increase frame pool size to 90% max memory
 
 Fixed:
 ^^^^^^


### PR DESCRIPTION
- Use thread pool for writing files in parallel
- Increase frame pool size to 90% max memory

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204624004754541