### PR TITLE
Fix buffer overrun, async init, unblock ui during init

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 Changelog for Nautilus
 ======================
-0.1.26 (2023-05-17)
+0.1.26 (2023-05-18)
 -------------------
 
 Added:
@@ -8,7 +8,12 @@ Added:
 - Delete files when autotiling
 - Update plate format files
 - Use thread pool for writing files in parallel
-- Increase frame pool size to 90% max memory
+- Allow frame pool size to 90% max memory, defaults to frameCount
+- ensure pool size of frameCount at acquisition start
+- enable async init by default
+- set busy wait cursor during initialize
+- move all init code to thread and disable ui until init is finished,
+  prevents ui from blocking
 
 Fixed:
 ^^^^^^

--- a/src/app/src/config.cpp
+++ b/src/app/src/config.cpp
@@ -204,7 +204,7 @@ Config::Config(std::filesystem::path cfg, cxxopts::ParseResult userargs) {
     testImgPath = "";
     if (userargs.count("test_img")) { testImgPath = userargs["test_img"].as<std::string>(); }
     ignoreErrors = toml::find_or<bool>(config, "debug", "ignore_errors", false);
-    asyncInit = toml::find_or<bool>(config, "debug", "async_init", false);
+    asyncInit = toml::find_or<bool>(config, "debug", "async_init", true);
 }
 
 void Config::Dump() {

--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -27,10 +27,11 @@
  *
  * @brief Main entrypoint into the nautilus application.
  *********************************************************************/
+#include <deque>
 #include <filesystem>
 #include <iostream>
-#include <deque>
 #include <stdlib.h>
+#include <thread>
 
 #include <cxxopts.hpp>
 #include <fmt/chrono.h>
@@ -150,7 +151,13 @@ int main(int argc, char* argv[]) {
 
         win.resize(800, 640);
         win.setVisible(true);
-        win.Initialize();
+
+        if (config->asyncInit) {
+            std::thread t([&] { win.Initialize(); });
+            t.detach();
+        } else {
+            win.Initialize();
+        }
 
         return app.exec();
     } else {

--- a/src/app/src/mainwindow.h
+++ b/src/app/src/mainwindow.h
@@ -105,6 +105,7 @@ class MainWindow : public QMainWindow {
         void sig_acquisition_done(bool runPostProcess);
         void sig_livescan_stopped();
         void sig_start_analysis();
+        void sig_enable_controls(bool enable);
 
     public slots:
         void acquisition_done(bool runPostProcess);
@@ -201,6 +202,8 @@ class MainWindow : public QMainWindow {
         QMovie* m_waitingMov;
 
     private:
+        void EnableAll(bool enable);
+
         void StartAcquisition(bool saveToDisk);
         void StopAcquisition();
 

--- a/src/cameras/include/pm/Acquisition.h
+++ b/src/cameras/include/pm/Acquisition.h
@@ -81,6 +81,7 @@ namespace pm {
                 std::mutex m_cbLock;
                 /* std::thread* m_writerThread{ nullptr }; */
 
+                uint64_t m_framesMax{0};
                 std::unique_ptr<FramePool<F>> m_unusedFramePool{nullptr};
 
                 uint32_t m_lastFrameInCallback{0};

--- a/src/common/include/FramePool.h
+++ b/src/common/include/FramePool.h
@@ -125,11 +125,13 @@ class FramePool {
          *
          * @param size Minimum size of frame pool.
          */
-        void EnsurePoolSize(uint16_t size) {
+        void EnsurePoolSize(uint64_t size) {
             std::lock_guard<std::mutex> lock(m_poolLock);
 
+            if (m_pool.size() < size) {
+                spdlog::info("EnsurePoolSize: pool size: {}, requested: {}", m_pool.size(), size);
+            }
             while (m_pool.size() < size) {
-                spdlog::info("Pool low, allocating");
                 m_pool.push(new F(m_frameBytes, m_deepCopy, m_pTask));
                 total_objs++;
             }


### PR DESCRIPTION
- adjust frame pool default size
- ensure pool size of frameCount at acquisition start
- enable async init by default
- set busy wait cursor during initialize
- move all init code to thread and disable ui until init is finished, prevents ui from blocking