### PR TITLE
Ext trigger

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,14 +3,13 @@ Changelog for Nautilus
 0.1.34 (2023-07-24)
 -------------------
 
-Updated:
+Added:
 ^^^^^^^
 - Set trigger mode to internal trigger when starting live view only
 - Change trigger to value in config when starting acquisition
 - Fully stop acquisition after stage move before restarting for next region
-
-Fixed:
-^^^^^^
+- Disable exit when post processing
+- Prevent line-wrapping in settings.toml for long paths
 - Error on non-E drive selection
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,19 @@
 Changelog for Nautilus
 ======================
+0.1.34 (2023-07-24)
+-------------------
+
+Updated:
+^^^^^^^
+- Set trigger mode to internal trigger when starting live view only
+- Change trigger to value in config when starting acquisition
+- Fully stop acquisition after stage move before restarting for next region
+
+Fixed:
+^^^^^^
+- Error on non-E drive selection
+
+
 0.1.33 (2023-07-12)
 -------------------
 

--- a/src/app/src/mainwindow.cpp
+++ b/src/app/src/mainwindow.cpp
@@ -1100,6 +1100,13 @@ void MainWindow::postProcess() {
 
         outfile << std::setw(100) << settings << std::endl;
 
+        const toml::basic_value<toml::preserve_comments, tsl::ordered_map> paths{
+            { "output_dir_path", m_expSettings.acquisitionDir.string() },
+            { "input_path", (m_expSettings.acquisitionDir / rawFile).string() },
+        };
+
+        outfile << std::setw(300) << paths << std::endl;
+
         //output platemap format
         if (m_config->plateFormat != "") {
             auto platemapFormat = toml::parse(m_config->plateFormat);

--- a/src/app/src/mainwindow.cpp
+++ b/src/app/src/mainwindow.cpp
@@ -1078,8 +1078,6 @@ void MainWindow::postProcess() {
             { "software_version", m_config->version },
             { "recording_date", m_recordingDateFmt },
             { "led_intensity", m_config->ledIntensity },
-            { "output_dir_path", m_expSettings.acquisitionDir.string() },
-            { "input_path", (m_expSettings.acquisitionDir / rawFile).string() },
             { "auto_contrast_brightness", !m_config->noAutoConBright },
             { "fps", m_config->fps },
             { "duration", m_config->duration },
@@ -1249,16 +1247,20 @@ void MainWindow::acquisitionThread(MainWindow* cls) {
 
 
 void MainWindow::closeEvent(QCloseEvent *event) {
-    m_userCanceled = true;
+    if (m_curState == PostProcessing || m_curState == PostProcessingLiveView) {
+        event->ignore();
+    } else {
+        m_userCanceled = true;
 
-    if (m_curState == LiveViewRunning) {
-        stopLiveView();
-    }
-    if (m_curState == AcquisitionRunning) {
-        stopAcquisition();
-    }
-    if (m_curState == LiveViewAcquisitionRunning) {
-        stopAcquisition_LiveViewRunning();
-        stopLiveView();
+        if (m_curState == LiveViewRunning) {
+            stopLiveView();
+        }
+        if (m_curState == AcquisitionRunning) {
+            stopAcquisition();
+        }
+        if (m_curState == LiveViewAcquisitionRunning) {
+            stopAcquisition_LiveViewRunning();
+            stopLiveView();
+        }
     }
 }

--- a/src/app/src/settings.cpp
+++ b/src/app/src/settings.cpp
@@ -26,6 +26,8 @@
 
 #include <QFileDialog>
 #include <QString>
+#include <QMessageBox>
+
 #include "settings.h"
 
 /*
@@ -59,9 +61,19 @@ Settings::~Settings() {
  */
 void Settings::on_dirChoiceBtn_clicked() {
     auto dir = QFileDialog::getExistingDirectory(this, "Select output directory", "E:\\");
+    QString prefix = "E:\\";
 
-    ui.dirChoice->setPlainText(dir);
-    spdlog::info("Selected dir: {}", dir.toStdString());
+    if (!dir.startsWith(prefix)) {
+        spdlog::error("Must use output directory on E:\\ drive, selected {}", dir.toStdString());
+        QMessageBox messageBox;
+        messageBox.critical(0, "Error", "Must select output directory on E:\\ drive");
+        messageBox.setFixedSize(500,200);
+
+    } else {
+        spdlog::info("Selected dir: {}", dir.toStdString());
+        ui.dirChoice->setPlainText(dir);
+    }
+
 }
 
 

--- a/src/cameras/src/pm/Acquisition.cpp
+++ b/src/cameras/src/pm/Acquisition.cpp
@@ -496,6 +496,8 @@ void pm::Acquisition<F, C>::WaitForStop() {
         
     }
 
+    m_camera->StopExp();
+
     m_capturedFrames = 0;
     m_state = AcquisitionState::AcqStopped;
     m_lastFrameInProcessing = m_lastFrameInCallback;


### PR DESCRIPTION
- Set trigger mode to internal trigger when starting live view only
- Change trigger to value in config when starting acquisition
- Fully stop acquisition after stage move before restarting for next region
- Disable exit when post processing
- Prevent line-wrapping in settings.toml for long paths
- Error on non-E drive selection