### PR TITLE
Change uint16_t frameCount argument in AutoTile to uint32_t to allow for

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Changed:
 
 - Plate format definitions
 
+Fixed:
+^^^^^^
+- frameCount narrowed to uint16_t in AutoTile call, overflows when number of frames above 65536, changed to uint32_t
+
 
 0.1.41 (2024-03-11)
 -------------------

--- a/src/common/include/PostProcess.h
+++ b/src/common/include/PostProcess.h
@@ -126,7 +126,7 @@ namespace PostProcess {
     void AutoTile(
         std::filesystem::path indir,
         std::string prefix,
-        uint16_t frames,
+        uint32_t frames,
         uint32_t rows,
         uint32_t cols,
         std::vector<uint8_t>& tileMap,


### PR DESCRIPTION
tiling longer acquisitions